### PR TITLE
Added a link to /microblog/ on every website page

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,13 +13,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 
 <br><br>
 <h3>404</h3>

--- a/50x.html
+++ b/50x.html
@@ -13,13 +13,13 @@
 <script src="theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 
 <br><br>
 <h3>internal error</h3>

--- a/about/index.html
+++ b/about/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <span id="current">about</span>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/admin/discord/blog/index.php
+++ b/admin/discord/blog/index.php
@@ -48,13 +48,13 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>#blog</h3>
 <br>

--- a/admin/discord/blog/success.php
+++ b/admin/discord/blog/success.php
@@ -16,8 +16,8 @@
     <script src="/theme.js"></script>
     <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-        <h1><a href="/index.html">fridge</a></h1>
-        <a href="/blog">blog</a>
+        <h1><a href="/">fridge</a></h1>
+        <a href="/microblog">[micro]</a><a href="/blog">blog</a>
         <a href="/about">about</a>
         <a href="/contact">contact</a>
         <a href="/projects">projects</a>

--- a/admin/discord/index.html
+++ b/admin/discord/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br>
 <h3>Select a Discord channel</h3>
 <div id="posts">

--- a/admin/discord/music/index.php
+++ b/admin/discord/music/index.php
@@ -50,13 +50,13 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>#music</h3>
 <br>

--- a/admin/discord/music/success.php
+++ b/admin/discord/music/success.php
@@ -16,8 +16,8 @@
     <script src="/theme.js"></script>
     <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-        <h1><a href="/index.html">fridge</a></h1>
-        <a href="/blog">blog</a>
+        <h1><a href="/">fridge</a></h1>
+        <a href="/microblog">[micro]</a><a href="/blog">blog</a>
         <a href="/about">about</a>
         <a href="/contact">contact</a>
         <a href="/projects">projects</a>

--- a/admin/discord/projects/index.php
+++ b/admin/discord/projects/index.php
@@ -48,13 +48,13 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>#projects</h3>
 <br>

--- a/admin/discord/projects/success.php
+++ b/admin/discord/projects/success.php
@@ -16,8 +16,8 @@
     <script src="/theme.js"></script>
     <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-        <h1><a href="/index.html">fridge</a></h1>
-        <a href="/blog">blog</a>
+        <h1><a href="/">fridge</a></h1>
+        <a href="/microblog">[micro]</a><a href="/blog">blog</a>
         <a href="/about">about</a>
         <a href="/contact">contact</a>
         <a href="/projects">projects</a>

--- a/admin/discord/updates/index.php
+++ b/admin/discord/updates/index.php
@@ -49,13 +49,13 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>#updates</h3>
 <br>

--- a/admin/discord/updates/success.php
+++ b/admin/discord/updates/success.php
@@ -16,8 +16,8 @@
     <script src="/theme.js"></script>
     <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-        <h1><a href="/index.html">fridge</a></h1>
-        <a href="/blog">blog</a>
+        <h1><a href="/">fridge</a></h1>
+        <a href="/microblog">[micro]</a><a href="/blog">blog</a>
         <a href="/about">about</a>
         <a href="/contact">contact</a>
         <a href="/projects">projects</a>

--- a/admin/index.html
+++ b/admin/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br>
 <h3>Admin</h3>
 <div id="posts">

--- a/admin/microblog/index.php
+++ b/admin/microblog/index.php
@@ -59,7 +59,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     header("Location: success.php?post_url=" . urlencode($post_link) . "&webhook_failed=1");
     exit;
     }
-    exit;
 }
 ?>
 

--- a/admin/microblog/index.php
+++ b/admin/microblog/index.php
@@ -77,13 +77,13 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Upload a Post</h3>
 <br>

--- a/blog/01/index.html
+++ b/blog/01/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Christmas PC Build 2023</h3>
 <h4>01 | 12th Jan 2024</h4>

--- a/blog/02/index.html
+++ b/blog/02/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>My New GPU: AMD Radeon RX 6700 XT</h3>
 <h4>02 | 27th Jan 2024</h4>

--- a/blog/03/index.html
+++ b/blog/03/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Legally streaming is overrated</h3>
 <h4>03 | 11th Mar 2024</h4>

--- a/blog/04/index.html
+++ b/blog/04/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Does my brain have its own conscience?</h3>
 <h4>04 | 24th Mar 2024</h4>

--- a/blog/05/index.html
+++ b/blog/05/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>I bought a compact digital camera</h3>
 <h4>05 | 09th Jun 2024</h4>

--- a/blog/06/index.html
+++ b/blog/06/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Website redesign!</h3>
 <h4>06 | 02nd Aug 2024</h4>

--- a/blog/07/index.html
+++ b/blog/07/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>The Devil's Laundry Service</h3>
 <h4>07 | 18th Oct 2024</h4>

--- a/blog/08/index.html
+++ b/blog/08/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Reclaiming The Desktop</h3>
 <h4>08 | 03rd Nov 2024</h4>

--- a/blog/09/index.html
+++ b/blog/09/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Learn about me and fridg3.org!</h3>
 <h4>09 | 25th Dec 2024</h4>

--- a/blog/10/index.html
+++ b/blog/10/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>I make music btw</h3>
 <h4>10 | 27th Dec 2024</h4>

--- a/blog/11/index.html
+++ b/blog/11/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Embracing criticism and staying authentic</h3>
 <h4>11 | 06th Jan 2025</h4>

--- a/blog/12/index.html
+++ b/blog/12/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>A world without bias</h3>
 <h4>12 | 20th Jan 2025</h4>

--- a/blog/13/index.html
+++ b/blog/13/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>I bought an MP3 player</h3>
 <h4>13 | 14th Apr 2025</h4>

--- a/blog/14/index.html
+++ b/blog/14/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>I wrote this blog post while drunk</h3>
 <h4>14 | 11th Jul 2025 (written April 19th 2025)</h4>

--- a/blog/15/index.html
+++ b/blog/15/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>Treating a ThinkPad like a Project Car (and why you should too)</h3>
 <h4>15 | 21st Jul 2025</h4>

--- a/blog/16/index.html
+++ b/blog/16/index.html
@@ -12,13 +12,13 @@
 <body>
 <div class="container">
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>fridgePack - Minecraft Hardcore on an already difficult modpack</h3>
 <h4>16 | 30th Aug 2025</h4>

--- a/blog/17/index.html
+++ b/blog/17/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>A review of Inertia by Pendulum</h3>
 <h4>17 | 02nd Sep 2025</h4>

--- a/blog/index.html
+++ b/blog/index.html
@@ -15,12 +15,11 @@
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
     <h1><a href="/index.html">fridge</a></h1>
-    <span id="current">blog</span>
+    <a href="/microblog">[micro]</a><span id="current">blog</span>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    <br><br><a href="/microblog">view microblog</a>
     </center>
 <br>
 

--- a/blog/wip/taylorswift/index.html
+++ b/blog/wip/taylorswift/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>A short review of every Taylor Swift song</h3>
 <h4>WIP | DDth Mon YYYY</h4>

--- a/contact/index.html
+++ b/contact/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <span id="current">contact</span>
     <a href="/projects">projects</a>

--- a/contact/thanks.html
+++ b/contact/thanks.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <span id="current">contact</span>
     <a href="/projects">projects</a>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
 <script src="theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/merch/index.html
+++ b/merch/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/microblog/post.php
+++ b/microblog/post.php
@@ -72,7 +72,7 @@ $title = "fridge | microblog post from $date";
     <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
         <h1><a href="https://fridg3.org">fridge</a></h1>
-        <a href="https://fridg3.org/blog">blog</a>
+        <a href="https://fridg3.org/microblog">[micro]</a><a href="https://fridg3.org/blog">blog</a>
         <a href="https://fridg3.org/about">about</a>
         <a href="https://fridg3.org/contact">contact</a>
         <a href="https://fridg3.org/projects">projects</a>
@@ -80,7 +80,7 @@ $title = "fridge | microblog post from $date";
     </center>
 <br>
 <h3>microblog</h3>
-<h4><a href='/microblog'>go to home</a></h4>
+<h4><a href='/microblog'>back to /microblog/</a></h4>
 <br>
     <div class="microblog-post">
         <b><?php echo $user; ?></b> <span id="microblog-date"><?php echo $date; ?></span><br>

--- a/microblog/template.html
+++ b/microblog/template.html
@@ -15,7 +15,7 @@
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
     <h1><a href="https://fridg3.org">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <span id="current">[micro]</span><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/baphomet/index.html
+++ b/music/cactile/baphomet/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/digitalpirates/index.html
+++ b/music/cactile/digitalpirates/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/engineer/index.html
+++ b/music/cactile/engineer/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/faceplant/index.html
+++ b/music/cactile/faceplant/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/fountainremix/index.html
+++ b/music/cactile/fountainremix/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/index.html
+++ b/music/cactile/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/kerosene/index.html
+++ b/music/cactile/kerosene/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/musicyoudontlike/index.html
+++ b/music/cactile/musicyoudontlike/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/poland/index.html
+++ b/music/cactile/poland/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/cactile/pyromaniac/index.html
+++ b/music/cactile/pyromaniac/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/andiamo/index.html
+++ b/music/frdg3/andiamo/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/digitalpirates/index.html
+++ b/music/frdg3/digitalpirates/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/howdoweconnect/index.html
+++ b/music/frdg3/howdoweconnect/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/index.html
+++ b/music/frdg3/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/andiamo/index.html
+++ b/music/frdg3/musicforinbetween/andiamo/index.html
@@ -13,8 +13,8 @@
 <div class="container">
 
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/breakbeatme/index.html
+++ b/music/frdg3/musicforinbetween/breakbeatme/index.html
@@ -13,8 +13,8 @@
 <div class="container">
 
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/howdoweconnect/index.html
+++ b/music/frdg3/musicforinbetween/howdoweconnect/index.html
@@ -13,8 +13,8 @@
 <div class="container">
 
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/index.html
+++ b/music/frdg3/musicforinbetween/index.html
@@ -32,8 +32,8 @@
 <body>
 <div class="container">
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/musicisfirstlove/index.html
+++ b/music/frdg3/musicforinbetween/musicisfirstlove/index.html
@@ -13,8 +13,8 @@
 <div class="container">
 
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/prerelease.html
+++ b/music/frdg3/musicforinbetween/prerelease.html
@@ -12,8 +12,8 @@
 <body>
 <div class="container">
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/frdg3/musicforinbetween/song4/index.html
+++ b/music/frdg3/musicforinbetween/song4/index.html
@@ -13,8 +13,8 @@
 <div class="container">
 
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/music/index.html
+++ b/music/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/others/index.html
+++ b/others/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
 <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/projects/frdgCanvas/docs/index.html
+++ b/projects/frdgCanvas/docs/index.html
@@ -13,13 +13,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>frdgCanvas</h3>
 <h4>Documentation</h4>

--- a/projects/frdgCanvas/download/index.html
+++ b/projects/frdgCanvas/download/index.html
@@ -14,7 +14,7 @@
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
     <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>

--- a/projects/frdgCanvas/download/index.html
+++ b/projects/frdgCanvas/download/index.html
@@ -13,7 +13,7 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
+    <h1><a href="/">fridge</a></h1>
     <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>

--- a/projects/frdgCanvas/index.html
+++ b/projects/frdgCanvas/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>frdgCanvas</h3>
 <h4>GTK3/Pygame Drawing Software made with Python</h4>

--- a/projects/fridgePack/index.html
+++ b/projects/fridgePack/index.html
@@ -13,16 +13,16 @@
 <div class="container">
 <script src="/theme.js"></script>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br>
 <img src="cover.jpg"><br>
-<a href="download/" id="downloadtext" target="_blank">Download (Google Drive)</a>
+<a href="download/" id="downloadtext">Download (Google Drive)</a>
 <a href="modlist/" id="downloadtext">Mod list</a>
 <br><br>
 fridgePack is a Minecraft modpack focused on survival, exploration, parkour and difficulty.

--- a/projects/fridgePack/index.html
+++ b/projects/fridgePack/index.html
@@ -22,7 +22,7 @@
 </center>
 <br>
 <img src="cover.jpg"><br>
-<a href="download/" id="downloadtext">Download (Google Drive)</a>
+<a href="download/" id="downloadtext" target="_blank">Download (Google Drive)</a>
 <a href="modlist/" id="downloadtext">Mod list</a>
 <br><br>
 fridgePack is a Minecraft modpack focused on survival, exploration, parkour and difficulty.

--- a/projects/fridgePack/modlist/index.html
+++ b/projects/fridgePack/modlist/index.html
@@ -12,13 +12,13 @@
 <body></body>
 <div class="container">
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br>
 <img src="../cover.jpg"><br>
 <a href="../" id="downloadtext">&lt; Go back</a>

--- a/projects/index.html
+++ b/projects/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <span id="current">projects</span>
@@ -24,6 +24,11 @@
 <br>
 
 <div id="posts">
+    <a href="/merch" id="postlink"><div class="post">
+        <div id="date">25th Aug 2025 | 05</div>
+        <h3>fridg3.org Merchandise</h3>
+        <p>A page to purchase merchandise that'll help fund this website's existence on the web. Buy yourself a shirt, a vest, or maybe even a vinyl or CD of one of my releases!</p>
+        <br></div></a>
     <a href="fridgePack/" id="postlink"><div class="post">
         <div id="date">28th Feb 2025 | 04</div>
         <h3>fridgePack - Minecraft Modpack</h3>

--- a/projects/osu!FRDG/index.html
+++ b/projects/osu!FRDG/index.html
@@ -14,13 +14,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <h3>osu!FRDG</h3>
 <h4>STD/Taiko  |  16:9 SD</h4>

--- a/projects/osu!FRDG/screenshots/index.html
+++ b/projects/osu!FRDG/screenshots/index.html
@@ -13,13 +13,13 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <h1><a href="/index.html">fridge</a></h1>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>
     <a href="/music">music</a>
-    </center>
+</center>
 <br><br>
 <img src="screenshot10.png">
 <br>

--- a/projects/ytmusic-playlist-downloader/index.html
+++ b/projects/ytmusic-playlist-downloader/index.html
@@ -14,8 +14,8 @@
 <script src="/theme.js"></script>
 <button id="change-theme"><i class="fas fa-sun"></i></button>
     <center>
-    <img src="icon.png"><a href="/index.html"></a></img><br>
-    <a href="/blog">blog</a>
+    <h1><a href="/">fridge</a></h1>
+    <a href="/microblog">[micro]</a><a href="/blog">blog</a>
     <a href="/about">about</a>
     <a href="/contact">contact</a>
     <a href="/projects">projects</a>


### PR DESCRIPTION
# Update Notes
Added a link to /microblog/ alongside the rest of the page links that appear on every website page
> As a result, almost every index.html file has been modified as part of this update.
> If the link is missing on any pages, let me know by pinging me on Discord or commenting on this update's Pull Request on GitHub.

Removed "view microblog" link from the top of /blog/

Updated "post.php" in /microblog/ *(the page that every microblog post uses as a reference)*
> Instead of saying "go to home", it'll say "back to microblog"

Added a link to /merch/ in /projects/index.html
> Title: "fridg3.org Merchandise"
> Description: "A page to purchase merchandise that'll help fund this website's existence on the web. Buy yourself a shirt, a vest, or maybe even a vinyl or CD of one of my releases!"
> The date used is "25th Aug 2025", although this might not be accurate since I can't remember when I released the page